### PR TITLE
For consideration: Use pm2 restart directly for more reliable restart

### DIFF
--- a/MMM-WatchDog.js
+++ b/MMM-WatchDog.js
@@ -3,7 +3,8 @@ Module.register("MMM-WatchDog",{
     // Default module config.
     defaults: {
         interval: 2,
-        timeout: 10
+        timeout: 10,
+        pm2_app: "MagicMirror"
     },
 
     // Override dom generator.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,15 @@ The following properties can be configured:
 		</tr>
         	<tr>
 			<td><code>timeout</code></td>
-			<td>The timeout in seconds before the MagicMirror² app quits.
+			<td>The timeout in seconds before the MagicMirror² app restarts.
 				<br><b>Default value:</b> <code>10</code>
+			</td>
+		</tr>
+        </tr>
+        	<tr>
+			<td><code>pm2_app</code></td>
+			<td>The name of the pm2 app to restart on failure.
+				<br><b>Default value:</b> <code>MagicMirror</code>
 			</td>
 		</tr>
 	</tbody>

--- a/node_helper.js
+++ b/node_helper.js
@@ -1,4 +1,6 @@
 var NodeHelper = require("node_helper");
+const exec = require('child_process').exec;
+
 module.exports = NodeHelper.create({
 
     // Create the timer object.
@@ -25,20 +27,20 @@ module.exports = NodeHelper.create({
 
         // Incoming PING. Reschedule restart.
         if (notification === 'PING') {
-            this.scheduleRestart();
+           this.scheduleRestart();
         }
     },
 
     // Reschedule restart by clearing old timer, and setting a new timer.
     scheduleRestart: function() {
         clearTimeout(this.timer);
-        this.timer = setTimeout(this.restart, this.config.timeout * 1000);
+        this.timer = setTimeout(() => {this.restart()}, this.config.timeout * 1000);
     },
 
-    // Quit Node process.
+    // Restart pm2 app
     restart: function() {
         var now = new Date();
-        console.error(now.toString() + ' - WatchDog: Heartbeat timeout. Frontend might have crashed. Exit now.');
-        process.exit(1);
+        console.error(now.toString() + ' - WatchDog: Heartbeat timeout. Frontend might have crashed. Restarting ' + this.config.pm2_app + ' now.');
+        exec("pm2 restart " + this.config.pm2_app, null);
     }
 });


### PR DESCRIPTION
Use pm2 restart directly for more reliable restart

- Use 'pm2 restart app' instead of just exiting, which pm2 won't be watching if using a wrapper script to launch MagicMirror
- Added config variable 'pm2_app' defaulted to 'MagicMirror'